### PR TITLE
Fix default sorting bug

### DIFF
--- a/tnrs-standalone/src/main/java/org/iplantc/tnrs/demo/client/RemoteTNRSEditorPanel.java
+++ b/tnrs-standalone/src/main/java/org/iplantc/tnrs/demo/client/RemoteTNRSEditorPanel.java
@@ -90,7 +90,7 @@ public class RemoteTNRSEditorPanel extends TNRSEditorPanel
 	private CheckMenuItem sources_n;
 	private CheckMenuItem  tax_on;
 	private RemoteTNRSEditorPanel panel;
-	private boolean dirty=false;
+	private boolean dirty=true;
 	private Button job_info;
 
 	/**


### PR DESCRIPTION
Currently, `dirty` is set to false by default when downloading results, and is only set back to true when best match settings are checked and then unchecked again. Setting dirty to the correct default value of true fixes this issue.